### PR TITLE
[2022-11-25 2nd PR] 로그인 에러 수정

### DIFF
--- a/src/main/java/com/golfzonTech4/worktalk/jwt/JwtFilter.java
+++ b/src/main/java/com/golfzonTech4/worktalk/jwt/JwtFilter.java
@@ -50,10 +50,12 @@ public class JwtFilter extends GenericFilterBean {
     * RequestHeader에서 토큰 정보를 꺼내오기 위한 resolveToken 메서드 추가
     */
    private String resolveToken(HttpServletRequest request) {
+      log.info("resolveToken");
       String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+      log.info("bearerToken: {}", bearerToken);
 
-      if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-         return bearerToken.substring(7);
+      if (StringUtils.hasText(bearerToken)) {
+         return bearerToken;
       }
 
       return null;


### PR DESCRIPTION
1. 로그인 에러 해결
 - JwtFilter 클래스 상의 requestHeader에서 받은 bearerToken 값에 조건이 잘못 적용되어 null로 인식 => 조건 변경을 통한 해결