### PR TITLE
[2022-11-27 1st PR] 예약 기능 추가 및 SecurityUtil 기능 추가

### DIFF
--- a/src/main/java/com/golfzonTech4/worktalk/WorktalkApplication.java
+++ b/src/main/java/com/golfzonTech4/worktalk/WorktalkApplication.java
@@ -2,7 +2,9 @@ package com.golfzonTech4.worktalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication()
 public class WorktalkApplication {
 

--- a/src/main/java/com/golfzonTech4/worktalk/controller/ReservationController.java
+++ b/src/main/java/com/golfzonTech4/worktalk/controller/ReservationController.java
@@ -1,13 +1,20 @@
 package com.golfzonTech4.worktalk.controller;
 
+import com.golfzonTech4.worktalk.domain.MemberType;
+import com.golfzonTech4.worktalk.domain.Reservation;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveCheckDto;
 import com.golfzonTech4.worktalk.dto.reservation.ReserveDto;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto;
 import com.golfzonTech4.worktalk.service.ReservationService;
+import com.golfzonTech4.worktalk.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +22,9 @@ import java.time.LocalDateTime;
 public class ReservationController {
     private final ReservationService reservationService;
 
+    /**
+     * 예약 요청
+     */
     @PostMapping("/reserve")
     public ResponseEntity<Long> reserve(@RequestBody ReserveDto reserveDto) {
 
@@ -23,10 +33,69 @@ public class ReservationController {
         return ResponseEntity.ok(result);
     }
 
-    @PostMapping("/cancel")
-    public ResponseEntity<LocalDateTime> cancel(@RequestBody ReserveDto reserveDto) {
-        log.info("cancel: {}, {}", reserveDto.getReserveId(), reserveDto.getCancelReason());
-        return ResponseEntity.ok(reservationService.cancel(reserveDto.getReserveId(), reserveDto.getCancelReason()));
+    /**
+     * 예약 취소 요청
+     */
+    @PostMapping("/reservation/cancel")
+    public ResponseEntity<LocalDateTime> cancelByUser(@RequestBody ReserveDto reserveDto) {
+        String currentUserRole = SecurityUtil.getCurrentUserRole().get();
+        if (currentUserRole.equals(MemberType.ROLE_USER)) {
+            log.info("cancelBy{}: {}, {}",currentUserRole, reserveDto.getReserveId(), reserveDto.getCancelReason());
+            return ResponseEntity.ok(reservationService.cancelByUser(reserveDto.getReserveId(), reserveDto.getCancelReason()));
+        } else {
+            log.info("cancelBy{}: {}, {}",currentUserRole, reserveDto.getReserveId(), reserveDto.getCancelReason());
+            return ResponseEntity.ok(reservationService.cancelByHost(reserveDto.getReserveId(), reserveDto.getCancelReason()));
+        }
+    }
+
+//    /**
+//     * 호스트 예약 취소 요청
+//     */
+//    @PostMapping("/host/cancel")
+//    public ResponseEntity<LocalDateTime> cancelByHost(@RequestBody ReserveDto reserveDto) {
+//        log.info("cancel: {}, {}", reserveDto.getReserveId(), reserveDto.getCancelReason());
+//    }
+
+    /**
+     * 예약 리스트 조회 요청
+     */
+    @GetMapping("/reservations")
+    public ResponseEntity<List<Reservation>> findAllByName() {
+        log.info("findAllByName");
+        return ResponseEntity.ok(reservationService.findAllByName());
+    }
+
+    /**
+     * 예약 리스트 조회 요청 (Spring Data JPA + JPQL)
+     */
+    @GetMapping("/reservations/user")
+    public ResponseEntity<List<ReserveSimpleDto>> findAllByUser() {
+        log.info("findAllByUser");
+        return ResponseEntity.ok(reservationService.findAllByUser());
+    }
+
+    @GetMapping("/reservations/host")
+    public ResponseEntity<List<ReserveSimpleDto>> findAllByHost() {
+        log.info("findAllByUser");
+        return ResponseEntity.ok(reservationService.findAllByHost());
+    }
+
+    /**
+     * 예약 리스트 조회 요청(QueryDsl)
+     */
+    @GetMapping("/reservations/query")
+    public ResponseEntity<List<ReserveSimpleDto>> findAllByUserQuery() {
+        log.info("findAllByUser");
+        return ResponseEntity.ok(reservationService.findAllByUserQuery());
+    }
+
+    /**
+     * 예약 리스트 조회 요청(선택된 기간/시간 기준)
+     */
+    @GetMapping("/reservations/isBooked")
+    public ResponseEntity<List<ReserveCheckDto>> findBookedRoom(@RequestBody ReserveCheckDto reserveCheckDto) {
+        log.info("findBookedRoom : {}", reserveCheckDto);
+        return ResponseEntity.ok(reservationService.findBookedReservation(reserveCheckDto));
     }
 
 }

--- a/src/main/java/com/golfzonTech4/worktalk/controller/UserController.java
+++ b/src/main/java/com/golfzonTech4/worktalk/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
     /**
      * 권한 모두 허용
      */
-    @GetMapping("/user")
+    @GetMapping("/")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_HOST', 'ROLE_MASTER')")
     public ResponseEntity<MemberDetailDto> getMyUserInfo(HttpServletRequest request) {
         log.info("getMyUserInfo: {}", request);
@@ -46,7 +46,7 @@ public class UserController {
     /**
      * HOST 권한만 허용
      */
-    @GetMapping("/user/{username}")
+    @GetMapping("/{username}")
     @PreAuthorize("hasAnyRole('ROLE_HOST')")
     public ResponseEntity<MemberDetailDto> getUserInfo(@PathVariable String username) {
         log.info("getUserInfo: {}", username);

--- a/src/main/java/com/golfzonTech4/worktalk/domain/BookDate.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/BookDate.java
@@ -18,9 +18,9 @@ public class BookDate {
 
     private LocalDateTime cancelDate; // 취소 일자
 
-    private LocalDate CheckInDate; // 사용 시작 일자
+    private LocalDate checkInDate; // 사용 시작 일자
 
-    private LocalDate CheckOutDate; // 사용 종료 일자
+    private LocalDate checkOutDate; // 사용 종료 일자
 
     private Integer checkInTime; // 사용 시작 시간
 
@@ -31,8 +31,8 @@ public class BookDate {
 
     public BookDate(LocalDateTime reserveDate, LocalDate checkInDate, LocalDate checkOutDate, Integer checkInTime, Integer checkOutTime) {
         this.reserveDate = reserveDate;
-        CheckInDate = checkInDate;
-        CheckOutDate = checkOutDate;
+        checkInDate = checkInDate;
+        checkOutDate = checkOutDate;
         this.checkInTime = checkInTime;
         this.checkOutTime = checkOutTime;
     }
@@ -43,7 +43,9 @@ public class BookDate {
 
     public static int getPeriodDate(LocalDate checkInDate, LocalDate checkOutDate) {
         int period;
-        if (checkOutDate.equals(checkOutDate)) { period = 1; }
+        if (checkOutDate.equals(checkOutDate)) {
+            period = 1;
+        }
         period = (int) ChronoUnit.DAYS.between(checkOutDate, checkInDate);
         System.out.println("period = " + period);
         return period;
@@ -52,13 +54,26 @@ public class BookDate {
     public static int getPeriodHours(int checkInTime, int checkOutTime) {
         return checkOutTime - checkInTime;
     }
+
     public static int getPeriodMinutes(LocalDateTime reserveDate, LocalDateTime cancelDate) {
-        return (int)ChronoUnit.MINUTES.between(reserveDate, cancelDate);
+        return (int) ChronoUnit.MINUTES.between(reserveDate, cancelDate);
     }
 
     public static LocalDateTime getInitTime(LocalDate checkInDate, Integer checkInTime) {
         LocalDateTime initTime = checkInDate.atTime(checkInTime, 0);
         return initTime;
+    }
+
+    public static boolean validTime(int checkInTime, int checkOutTime) {
+        if (checkInTime <= checkInTime) return true;
+        else return false;
+    }
+
+    public static boolean validDate(LocalDate checkInDate, LocalDate checkOutDate) {
+        if (checkInDate.isAfter(checkOutDate) || // 입실 날짜가 퇴실 날짜보다 늦은 경우
+                checkInDate.isAfter(LocalDate.now()) // 입실 날짜가 예약일을 이미 지난 경우
+        ) return true;
+        else return false;
     }
 
 }

--- a/src/main/java/com/golfzonTech4/worktalk/domain/Mileage.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/Mileage.java
@@ -22,7 +22,9 @@ public class Mileage implements Serializable {
     @Column(length = 20)
     private Mileage_status status;
 
-    private int amount;
+    @Column(name = "MILEAGE_AMOUNT")
+    private int mileageAmount;
 
-    private LocalDateTime m_date;
+    @Column(name = "MILEAGE_DATE")
+    private LocalDateTime mileageDate;
 }

--- a/src/main/java/com/golfzonTech4/worktalk/domain/Pay.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/Pay.java
@@ -26,11 +26,8 @@ public class Pay {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "PAY_STATUS", length = 50)
-    private Payment_status payStatus;
+    private PaymentStatus payStatus;
 
     @Column(name = "AMOUNT")
     private int payAmount;
-
-    @Column(name = "PAY_DATE")
-    private LocalDateTime payDate;
 }

--- a/src/main/java/com/golfzonTech4/worktalk/domain/PaymentStatus.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.golfzonTech4.worktalk.domain;
+
+public enum PaymentStatus {
+    UNPAID, DEPOSIT, PREPAID, POSTPAID, REFUND
+}

--- a/src/main/java/com/golfzonTech4/worktalk/domain/Payment_status.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/Payment_status.java
@@ -1,5 +1,0 @@
-package com.golfzonTech4.worktalk.domain;
-
-public enum Payment_status {
-    DEPOSIT, PREPAID, POSTPAID, REFUND
-}

--- a/src/main/java/com/golfzonTech4/worktalk/domain/Reservation.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/Reservation.java
@@ -27,23 +27,15 @@ public class Reservation {
     @Column(name = "RESERVATION_STATUS", length = 20)
     private ReserveStatus reserveStatus; // 예약 상태 (BOOKED, CANCELED_BY_USER, CANCELED_BY_HOST, USED)
 
-    @Column(name = "PAY_STATUS")
-    private int payStatus; // 결제 상태 : 보증금 or 선결제 (결제: 0, 미결제: 1)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "PAYMENT_STATUS", length = 20)
+    private PaymentStatus paymentStatus; // 결제 방법 (DEPOSIT, PREPAID, POSTPAID, REFUND)
+    @Column(name = "PAID")
+    private int paid; // 결제 상태 : 보증금 or 선결제 (결제: 0, 미결제: 1)
+
 
     @Embedded
     private BookDate bookDate;
-
-//    @Column(name = "RESERVATION_DATE")
-//    private LocalDateTime reserveDate; // 예약 일자
-//
-//    @Column(name = "CHECK_IN_DATE")
-//    private LocalDate CheckInDate; // 사용 일자
-//
-//    @Column(name = "CHECK_IN_TIME")
-//    private Integer checkInTime; // 사용 시작 시간
-//
-//    @Column(name = "CHECK_OUT_TIME")
-//    private Integer checkOutTime; // 사용 종료 시간
 
     @Column(name = "AMOUNT")
     private int reserveAmount; // 예상 금액
@@ -57,7 +49,7 @@ public class Reservation {
                 "reserveId=" + reserveId +
                 ", room=" + room +
                 ", reserveStatus=" + reserveStatus +
-                ", payStatus=" + payStatus +
+                ", paid=" + paid +
                 ", bookDate=" + bookDate +
                 ", reserveAmount=" + reserveAmount +
                 ", cancelReason='" + cancelReason + '\'' +
@@ -69,7 +61,8 @@ public class Reservation {
         reservation.setMember(member);
         reservation.setRoom(room);
         reservation.setReserveStatus(ReserveStatus.BOOKED);
-        reservation.setPayStatus(0);
+        reservation.setPaymentStatus(PaymentStatus.UNPAID); // 초기 설정 값: UNPAID
+        reservation.setPaid(0);
         reservation.setBookDate(bookDate);
         reservation.setReserveAmount(calAmount(room, bookDate));
         

--- a/src/main/java/com/golfzonTech4/worktalk/domain/ReserveStatus.java
+++ b/src/main/java/com/golfzonTech4/worktalk/domain/ReserveStatus.java
@@ -1,5 +1,5 @@
 package com.golfzonTech4.worktalk.domain;
 
 public enum ReserveStatus {
-    BOOKED, CANCELED_BY_USER, CANCELED_BY_HOST, USED
+    BOOKED, CANCELED_BY_USER, CANCELED_BY_HOST, USED, NOSHOW
 }

--- a/src/main/java/com/golfzonTech4/worktalk/dto/reservation/ReserveCheckDto.java
+++ b/src/main/java/com/golfzonTech4/worktalk/dto/reservation/ReserveCheckDto.java
@@ -1,0 +1,30 @@
+package com.golfzonTech4.worktalk.dto.reservation;
+
+import com.golfzonTech4.worktalk.domain.RoomType;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class ReserveCheckDto {
+
+    private Long roomId;
+    private RoomType roomType;
+    private LocalDate initDate;
+    private LocalDate endDate;
+    private int initTime;
+    private int endTime;
+
+    @QueryProjection
+    public ReserveCheckDto(Long roomId, LocalDate initDate, LocalDate endDate, int initTime, int endTime) {
+        this.roomId = roomId;
+        this.initDate = initDate;
+        this.endDate = endDate;
+        this.initTime = initTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/golfzonTech4/worktalk/dto/reservation/ReserveSimpleDto.java
+++ b/src/main/java/com/golfzonTech4/worktalk/dto/reservation/ReserveSimpleDto.java
@@ -1,0 +1,56 @@
+package com.golfzonTech4.worktalk.dto.reservation;
+
+import com.golfzonTech4.worktalk.domain.BookDate;
+import com.golfzonTech4.worktalk.domain.PaymentStatus;
+import com.golfzonTech4.worktalk.domain.ReserveStatus;
+import com.golfzonTech4.worktalk.domain.RoomType;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ReserveSimpleDto {
+    // 공간명(space), 세부공간명(room), 예약번호(reserve), 예약일(reserve),
+    // 사용일(reserve), 예약자(reserve), 예약 상태(reserve), 공급자 연락처(space_member)
+
+    private String roomName;
+    private int paid;
+    private Long reserveId;
+    private Long memberId;
+    private Long rooomId;
+    private BookDate bookDate;
+    private String name;
+    private ReserveStatus reserveStatus;
+    private PaymentStatus paymentStatus;
+    private RoomType roomType;
+
+
+
+    @QueryProjection
+    public ReserveSimpleDto(String roomName, Long reserveId, Long memberId, Long rooomId, BookDate bookDate, String name, ReserveStatus reserveStatus, PaymentStatus paymentStatus, RoomType roomType, int paid) {
+        this.roomName = roomName;
+        this.reserveId = reserveId;
+        this.memberId = memberId;
+        this.rooomId = rooomId;
+        this.bookDate = bookDate;
+        this.name = name;
+        this.reserveStatus = reserveStatus;
+        this.paymentStatus = paymentStatus;
+        this.roomType = roomType;
+        this.paid = paid;
+    }
+
+    @QueryProjection
+    public ReserveSimpleDto(Long reserveId, BookDate bookDate, String name, ReserveStatus reserveStatus) {
+        this.reserveId = reserveId;
+        this.bookDate = bookDate;
+        this.name = name;
+        this.reserveStatus = reserveStatus;
+    }
+    @QueryProjection
+    public ReserveSimpleDto(Long reserveId, Long memberId) {
+        this.reserveId = reserveId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/golfzonTech4/worktalk/jwt/JwtFilter.java
+++ b/src/main/java/com/golfzonTech4/worktalk/jwt/JwtFilter.java
@@ -50,9 +50,7 @@ public class JwtFilter extends GenericFilterBean {
     * RequestHeader에서 토큰 정보를 꺼내오기 위한 resolveToken 메서드 추가
     */
    private String resolveToken(HttpServletRequest request) {
-      log.info("resolveToken");
       String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-      log.info("bearerToken: {}", bearerToken);
 
       if (StringUtils.hasText(bearerToken)) {
          return bearerToken;

--- a/src/main/java/com/golfzonTech4/worktalk/repository/ReservationRepository.java
+++ b/src/main/java/com/golfzonTech4/worktalk/repository/ReservationRepository.java
@@ -1,8 +1,0 @@
-package com.golfzonTech4.worktalk.repository;
-
-import com.golfzonTech4.worktalk.domain.Reservation;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-
-}

--- a/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationRepository.java
@@ -1,0 +1,19 @@
+package com.golfzonTech4.worktalk.repository.reservation;
+
+import com.golfzonTech4.worktalk.domain.Reservation;
+import com.golfzonTech4.worktalk.domain.ReserveStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    /**
+     * 접속자가 가진 예약 리스트를 조회하는 쿼리 => 성능 문제 발생 (reservation 조회 => member 조회 => room 조회 => member 조회)
+     */
+    @Query("select r from Reservation r where r.member.name = :name order by r.reserveId desc ")
+    public List<Reservation> findAllByName(@Param("name") String name);
+
+}

--- a/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepository.java
+++ b/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepository.java
@@ -1,0 +1,43 @@
+package com.golfzonTech4.worktalk.repository.reservation;
+
+import com.golfzonTech4.worktalk.domain.*;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReservationSimpleRepository extends JpaRepository<Reservation, Long>, ReservationSimpleRepositoryCustom{
+
+    // JPQL + Spring DATA JPA를 활용한 회원 예약 리스트 조회 (연관관계 초기화 이슈 없음.)
+    @Query("select " +
+            "new com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto" +
+            "(ro.roomName, r.reserveId,m.id, ro.roomId, b, m.name, r.reserveStatus, r.paymentStatus, ro.roomType, r.paid)" +
+            "from Reservation r " +
+            "join r.member m " +
+            "join r.bookDate b " +
+            "join r.room ro " +
+            "where r.member.name = :name " +
+            "order by r.reserveId desc ")
+    List<ReserveSimpleDto> findAllByUser(@Param("name") String name);
+
+    @Query("select " +
+            "new com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto" +
+            "(ro.roomName, r.reserveId,m.id, ro.roomId, b, m.name, r.reserveStatus, r.paymentStatus, ro.roomType, r.paid)" +
+            "from Reservation r " +
+            "join r.member m " +
+            "join r.bookDate b " +
+            "join r.room ro " +
+            "join ro.space s " +
+            "where s.member.name = :name " +
+            "order by r.reserveId desc ")
+    List<ReserveSimpleDto> findAllByHost(@Param("name") String name);
+
+    // QueryDsl를 활용한 회원 예약 리스트 조회 (연관관계 초기화 이슈 존재 => 연관관계 depth >= 3일 경우 @QueryInit 필요)
+    List<ReserveSimpleDto> findAllByUserQuery(String name);
+    List<ReserveSimpleDto> findAllByTime();
+
+    Long countNoShow(Long memberId, ReserveStatus reserveStatus);
+
+}

--- a/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepositoryCustom.java
+++ b/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepositoryCustom.java
@@ -1,0 +1,19 @@
+package com.golfzonTech4.worktalk.repository.reservation;
+
+import com.golfzonTech4.worktalk.domain.ReserveStatus;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveCheckDto;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReservationSimpleRepositoryCustom {
+
+    List<ReserveSimpleDto> findAllByUserQuery(String name);
+    List<ReserveSimpleDto> findAllByTime();
+    Long countNoShow(Long memberId, ReserveStatus reserveStatus);
+
+    List<ReserveCheckDto> findBookedOffice(Long roomId, LocalDate initDate, LocalDate endDate);
+    List<ReserveCheckDto> findBookedRoom(Long roomId, LocalDate initDate, int initTime, int endTime);
+
+}

--- a/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepositoryImpl.java
+++ b/src/main/java/com/golfzonTech4/worktalk/repository/reservation/ReservationSimpleRepositoryImpl.java
@@ -1,0 +1,120 @@
+package com.golfzonTech4.worktalk.repository.reservation;
+
+import com.golfzonTech4.worktalk.domain.PaymentStatus;
+import com.golfzonTech4.worktalk.domain.ReserveStatus;
+import com.golfzonTech4.worktalk.domain.RoomType;
+import com.golfzonTech4.worktalk.dto.reservation.QReserveCheckDto;
+import com.golfzonTech4.worktalk.dto.reservation.QReserveSimpleDto;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveCheckDto;
+import com.golfzonTech4.worktalk.dto.reservation.ReserveSimpleDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.golfzonTech4.worktalk.domain.QReservation.reservation;
+
+@Slf4j
+public class ReservationSimpleRepositoryImpl implements ReservationSimpleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ReservationSimpleRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<ReserveSimpleDto> findAllByUserQuery(String name) {
+        log.info("findAllByUser : {}", name);
+
+        List<ReserveSimpleDto> result = queryFactory.select(new QReserveSimpleDto(
+                        reservation.room.roomName,
+                        reservation.reserveId,
+                        reservation.member.id,
+                        reservation.room.roomId,
+                        reservation.bookDate,
+                        reservation.member.name,
+                        reservation.reserveStatus,
+                        reservation.paymentStatus,
+                        reservation.room.roomType,
+                        reservation.paid)
+                )
+                .from(reservation)
+                .where(reservation.member.name.eq(name)).fetch();
+
+        return result;
+    }
+
+    @Override
+    public List<ReserveSimpleDto> findAllByTime() {
+        log.info("findAllByTime");
+        int hour = LocalDateTime.now().getHour() + 1; // 현재 시간에서 1시간을 뺀 값: 매 시간 30분에 조회되기에 시간만 비교하면됨.
+        log.info("hour: {}", hour);
+        // 예시: 12시 30분 조회 시 => 13시의 예약 데이터들을 조회.
+        List<ReserveSimpleDto> result = queryFactory.select(new QReserveSimpleDto(
+                        reservation.reserveId,
+                        reservation.member.id)
+                )
+                .from(reservation)
+                .where(reservation.bookDate.checkInTime.eq(hour) // 이용시간이 임박한 예약건 들 중
+                        .and(reservation.paymentStatus.eq(PaymentStatus.PREPAID)) // 선결제 중
+                        .and(reservation.paid.eq(0))) // 결제가 되지 않은 예약
+                .fetch();
+
+        log.info("result.size() : {}", result.size());
+
+        return result;
+    }
+
+    @Override
+    public Long countNoShow(Long memberId, ReserveStatus reserveStatus) {
+        log.info("findAllByTime : {}, {}", memberId, reserveStatus);
+
+        return queryFactory.select(new QReserveSimpleDto(
+                        reservation.reserveId,
+                        reservation.member.id)
+                )
+                .from(reservation)
+                .where(reservation.member.id.eq(memberId) // 해당 접속자의 예약 건들 중
+                        .and(reservation.reserveStatus.eq(reserveStatus))) // 예약 상태가 NoShow인 예약들
+                .fetch().stream().count(); // 의 횟수를 집계하여 반환
+    }
+
+    @Override
+    public List<ReserveCheckDto> findBookedOffice(Long reserveId, LocalDate initDate, LocalDate endDate) {
+        log.info("findBookedOffice : {}, {}, {}, {}", reserveId, initDate, endDate);
+        return queryFactory.select(new QReserveCheckDto(
+                        reservation.room.roomId,
+                        reservation.bookDate.checkInDate,
+                        reservation.bookDate.checkOutDate,
+                        reservation.bookDate.checkInTime,
+                        reservation.bookDate.checkOutTime
+                ))
+                .from(reservation)
+                .where(reservation.room.roomType.eq(RoomType.OFFICE)
+                        .and(reservation.bookDate.checkInDate.between(initDate, endDate)
+                                .or(reservation.bookDate.checkOutDate.between(initDate, endDate))))
+                .fetch();
+    }
+
+    @Override
+    public List<ReserveCheckDto> findBookedRoom(Long roomId, LocalDate initDate, int initTime, int endTime) {
+        log.info("findBookedOffice : {}, {}, {}, {}", roomId, initDate, initTime, endTime);
+        return queryFactory.select(new QReserveCheckDto(
+                        reservation.room.roomId,
+                        reservation.bookDate.checkInDate,
+                        reservation.bookDate.checkOutDate,
+                        reservation.bookDate.checkInTime,
+                        reservation.bookDate.checkOutTime
+                ))
+                .from(reservation)
+                .where(reservation.bookDate.checkInDate.eq(initDate)
+                        .and(reservation.room.roomType.ne(RoomType.OFFICE))
+                        .and(reservation.bookDate.checkInTime.between(initTime, endTime)
+                                .or(reservation.bookDate.checkOutTime.between(initTime, endTime))))
+                .fetch();
+    }
+}

--- a/src/main/java/com/golfzonTech4/worktalk/util/SecurityUtil.java
+++ b/src/main/java/com/golfzonTech4/worktalk/util/SecurityUtil.java
@@ -1,11 +1,15 @@
 package com.golfzonTech4.worktalk.util;
 
+import com.golfzonTech4.worktalk.domain.MemberType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class SecurityUtil {
@@ -17,10 +21,10 @@ public class SecurityUtil {
     * Security Context의 Authentication 객체를 이용해 username을 리턴해주는 메서드
     */
    public static Optional<String> getCurrentUsername() {
+      final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
       // Security context에 Authenrication객체가 저장되는 시점
       // JwtFilter의 doFilter메서드에서 request가 들어올때
       // SecurityContext에 Authentication 객체를 저장해서 사용하게 된다.
-      final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
       if (authentication == null) {
          log.debug("Security Context에 인증 정보가 없습니다.");
@@ -36,5 +40,24 @@ public class SecurityUtil {
       }
 
       return Optional.ofNullable(username);
+   }
+
+   public static Optional<String> getCurrentUserRole() {
+      final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      if (authentication == null) {
+         log.debug("Security Context에 인증 정보가 없습니다.");
+         return Optional.empty();
+      }
+
+      String authorities = null;
+      if (authentication.getPrincipal() instanceof UserDetails) {
+         UserDetails springSecurityUser = (UserDetails) authentication.getPrincipal();
+         authorities = springSecurityUser.getAuthorities().stream()
+                 .map(GrantedAuthority::getAuthority)
+                 .collect(Collectors.joining(","));
+      }
+
+      return Optional.ofNullable(authorities);
    }
 }


### PR DESCRIPTION
1. 예약 기능 추가
 A. 예약 조회 기능 추가
  - 지연 로딩으로 인한 예약 조회 실패 이슈 => DTO를 이용한 조회로 해결 및 QueryDsl 적용
  - 일자 및 시간 기준 예약 내역 조회 기능 추가
  - 접속자 회원명 기준 예약 내역 조회 기능 추가
 B. 예약 취소 기능 개선
  - 접속자 권한에 따른 분기 추가 (사용자, 호스트)
 C. 예약 노쇼 처리 기능 추가
  - 매 시각 30분마다 자동으로 조회하게 기능 구현 (Scheduler 사용)
  - 정해진 시간마다 결제기한 도래한 미결제 예약 내역 조회 기능 추가
  - 해당 결제의 상태를 "NOSHOW"로 수정하는 기능 추가
  - NOSHOW한 회원의 NOSHOW 내역 조회하는 기능 추가
  
2. SecurityUtil 기능 추가
 - getCurrentUserRole 매서드 추가: SecurityContext 상의 유저의 권한을 불러오는 매서드